### PR TITLE
Add beta57 Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This repository provides additional samplers to the Forge Neo WebUI.
   - SSPRK3
  
 - Additional Schedulers
-  - Linear Log 
+  - Linear Log
+  - Beta 57
 
 Adds a new extension accordian titled "Extra Samplers" to allow adjusting certain samplers.
 

--- a/lib_es/extra_schedulers/__init__.py
+++ b/lib_es/extra_schedulers/__init__.py
@@ -1,6 +1,8 @@
+from lib_es.extra_schedulers.beta57 import beta_57
 from lib_es.extra_schedulers.linear_log import linear_log
 
 
 __all_schedulers__ = [
+    beta_57,
     linear_log,
 ]

--- a/lib_es/extra_schedulers/beta57.py
+++ b/lib_es/extra_schedulers/beta57.py
@@ -23,5 +23,5 @@ def beta_57(
 
     opts.beta_dist_alpha = current_alpha
     opts.beta_dist_beta = current_beta
-    
+
     return tensor

--- a/lib_es/extra_schedulers/beta57.py
+++ b/lib_es/extra_schedulers/beta57.py
@@ -1,0 +1,27 @@
+import torch
+
+from lib_es.utils import scheduler_metadata
+from modules.sd_schedulers import beta_scheduler
+from modules.shared import opts
+
+
+@scheduler_metadata(name="beta_57", alias="Beta 57", need_inner_model=True)
+def beta_57(
+    n: int,
+    sigma_min: float,
+    sigma_max: float,
+    inner_model,
+    device: torch.device,
+) -> torch.Tensor:
+    current_alpha = opts.beta_dist_alpha
+    current_beta = opts.beta_dist_beta
+
+    opts.beta_dist_alpha = 0.5
+    opts.beta_dist_beta = 0.7
+
+    tensor = beta_scheduler(n, sigma_min, sigma_max, inner_model, device)
+
+    opts.beta_dist_alpha = current_alpha
+    opts.beta_dist_beta = current_beta
+    
+    return tensor

--- a/scripts/extra_samplers.py
+++ b/scripts/extra_samplers.py
@@ -222,6 +222,14 @@ class ExtraSamplerExtension(scripts.Script):
                     consts.GE_VALIDATE_SCHEDULE: validate_schedule,
                 },
             )
+        elif p.scheduler == "beta_57" or p.scheduler == "Beta 57": 
+            self.get_values_and_apply(
+                p,
+                {
+                    "Beta schedule alpha": 0.5,
+                    "Beta schedule beta": 0.7,
+                },
+            )
 
 
 section = ("exs", "Extra Samplers")

--- a/scripts/extra_samplers.py
+++ b/scripts/extra_samplers.py
@@ -222,7 +222,7 @@ class ExtraSamplerExtension(scripts.Script):
                     consts.GE_VALIDATE_SCHEDULE: validate_schedule,
                 },
             )
-        elif p.scheduler == "beta_57" or p.scheduler == "Beta 57": 
+        elif p.scheduler == "beta_57" or p.scheduler == "Beta 57":
             self.get_values_and_apply(
                 p,
                 {


### PR DESCRIPTION
Adds beta_57 to the schedulers drop down.

Nothing fancy about it - it just simplifies the process of setting the alpha/beta dist values in the settings. You can use my other extension [Simple Sigmas](https://github.com/MisterChief95/sd-forge-simple-sigmas) instead if you want more advanced options for scheduling.